### PR TITLE
Fix ubuntu/debian dependencies install command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Notice that you may have to `yum install epel-release` as well if you're attempt
 On Ubuntu or Debian, it would require something like this:
 
 	aptitude install libmicrohttpd-dev libjansson-dev \
-		libssl-dev libsrtp-dev libsofia-sip-ua-dev libglib2.0-dev \
+		libssl-dev libsrtp2-dev libsofia-sip-ua-dev libglib2.0-dev \
 		libopus-dev libogg-dev libcurl4-openssl-dev liblua5.3-dev \
 		libconfig-dev pkg-config libtool automake
 


### PR DESCRIPTION
in both ubuntu and debian libsrtp-dev doesnt exists but libsrtp2-dev does. and dependencies part of readme says atleast v2 of libsrtp is required.

Sources.
https://packages.ubuntu.com/libsrtp-dev
https://packages.ubuntu.com/libsrtp2-dev
https://packages.debian.org/libsrtp-dev
https://packages.debian.org/libsrtp2-dev